### PR TITLE
ENH: Return an nd.array from matlab, instead of a list of nd.arrays

### DIFF
--- a/Experiments/MoCoReg_Func_Test.ipynb
+++ b/Experiments/MoCoReg_Func_Test.ipynb
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "a5bd81a5-4692-44b0-aa5d-a5d4d6c8b5a9",
    "metadata": {},
    "outputs": [
@@ -41,46 +41,85 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Keyframes = [0, 32, 64, 84, 94, 104, 109, 114, 119, 124, 129, 134, 139, 144, 149, 154, 159, 164, 174, 184, 199]\n",
+      "Keyframes = [0, 32, 57, 72, 82, 92, 102, 107, 112, 117, 122, 127, 132, 137, 142, 147, 157, 167, 177, 192, 199]\n",
       "Registering set 1 of 20: Frame = 32\n",
-      "Registering set 2 of 20: Frame = 64\n",
-      "Registering set 3 of 20: Frame = 84\n",
-      "Registering set 4 of 20: Frame = 94\n",
-      "Registering set 5 of 20: Frame = 104\n",
-      "Registering set 6 of 20: Frame = 109\n",
-      "Registering set 7 of 20: Frame = 114\n",
-      "Registering set 8 of 20: Frame = 119\n",
-      "Registering set 9 of 20: Frame = 124\n",
-      "Registering set 10 of 20: Frame = 129\n",
-      "Registering set 11 of 20: Frame = 134\n",
-      "Registering set 12 of 20: Frame = 139\n",
-      "Registering set 13 of 20: Frame = 144\n",
-      "Registering set 14 of 20: Frame = 149\n",
-      "Registering set 15 of 20: Frame = 154\n",
-      "Registering set 16 of 20: Frame = 159\n"
+      "Registering set 2 of 20: Frame = 57\n",
+      "Registering set 3 of 20: Frame = 72\n",
+      "Registering set 4 of 20: Frame = 82\n",
+      "Registering set 5 of 20: Frame = 92\n",
+      "Registering set 6 of 20: Frame = 102\n",
+      "Registering set 7 of 20: Frame = 107\n",
+      "Registering set 8 of 20: Frame = 112\n",
+      "Registering set 9 of 20: Frame = 117\n",
+      "Registering set 10 of 20: Frame = 122\n",
+      "Registering set 11 of 20: Frame = 127\n",
+      "Registering set 12 of 20: Frame = 132\n",
+      "Registering set 13 of 20: Frame = 137\n",
+      "Registering set 14 of 20: Frame = 142\n",
+      "Registering set 15 of 20: Frame = 147\n",
+      "Registering set 16 of 20: Frame = 157\n",
+      "Registering set 17 of 20: Frame = 167\n",
+      "Registering set 18 of 20: Frame = 177\n",
+      "Registering set 19 of 20: Frame = 192\n",
+      "Registering set 20 of 20: Frame = 199\n",
+      "Done!\n",
+      "Registration time = 103.1041185\n",
+      "Before registration MSE = 6462.921507822512\n",
+      "After registration MSE = 6462.921507962111\n"
      ]
     }
    ],
    "source": [
-    "transforms = mocoreg_func(app.data_array, debug=True)"
+    "transforms = mocoreg_func(app.data_array, frames_per_second=500, debug=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "93c65b00-e413-49e4-ad70-db1578918b7a",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "199\n"
+     ]
+    }
+   ],
    "source": [
     "print(len(transforms))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "02cbfd66-c355-4379-8dd7-41332cc5b1b1",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x2c608e675b0>]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAAD4CAYAAAD8Zh1EAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAAqOElEQVR4nO3deXxU9b3/8dcnOwnZZ4CQBAIkAdnCEhABg1stLhVblyJStXpLrWJraxfvbX+2197e22qrF1utglvdtbYitlj3FtkCCQlhkSUJWwKB7CvZv78/ZuBGJMkAM3NmJp/n48HDmTOHzNuTyZuT7znne8QYg1JKKf8XZHUApZRS7qGFrpRSAUILXSmlAoQWulJKBQgtdKWUChAhVr2xzWYzaWlpVr29Ukr5pfz8/CpjjP10r1lW6GlpaeTl5Vn19kop5ZdE5EBvr+mQi1JKBQgtdKWUChBa6EopFSC00JVSKkBooSulVIDQQldKqQChha6UUgFCC10p5TX7q5p5M7+M7m6dttsTLLuwSCk1sNS1tPONZ3M5VHOctwvLefTrU7ANDrc6VkDRPXSllMd1dxvufb2QivpW7rpoDJv21XDlsk/ZUFJtdbSAooWulPK4ZR/t5Z+7K/n5Vybw4/njWHn3HAZHhHDz0xtZ9uFeunQIxi200JVSHvXxrqMs+2gv101L4ebzRwBwXlIM7yydy4IpyTz64R5ueTaXysY2i5P6Py10pZTHHKxu4d7XChmfFMOvvjoRETn5WlR4CI/cmMVD100m/0AtVz72KeuLqyxM6/+00JVSHnG8vYtvv5SPiPDk4ulEhAZ/YR0R4cYZqbx991xiIkK4+ZlcHv1gjw7BnCUtdKWU2xlj+OnKbeyqaOB/F05hRGJkn+uPHRbNqqVz+erUZJZ9tJfFT+dyrLHVS2kDhxa6UsrtXso9yF+3lPO9SzO4eOwQl/6OYwhmCg9fP5mCQ7VcuexT1u7VIZgzoYWulHKrLQdrefCdHVw81s53L8k4479/Q3Yqq5bOJS4yjG88m8sj7+/WIRgXaaErpdymqqmNu17aQlLsIP7361MJCpL+/9JpZA6NZtXSOVw3LYXHPi5m0YqNHG3QIZj+aKErpdyis6ube14poLalnT8unkZsZOg5fb3IsBB+e0MWv70hi6Kyeq5c9ilr9lS6KW1g0kJXSrnFw+/tZkNpNf/91UlMGB7rtq97/fQUVi2dQ+LgMG59bhNvF5a77WsHGi10pdQ5e3fbEZ5aU8riWSO4bnqK279+xtBo3r57LjPSEvjJX4rYXl7v9vcIBFroSqlzUnysiR/+eStTR8TxwNUTPPY+g8KCeXzRNOIjw7jzpXxqm9s99l7+SgtdKXXWmto6ufOlfCJCg3ni5mmEhXi2UuzR4Ty5eDrHGtu459UCOru6Pfp+/qbfrS8iz4rIMRHZ3svrN4tIkYhsE5H1IpLl/phKKV9jjOEnbxZRWtnE7xdNJSl2kFfeNys1jv+6diJri6t4+P3dXnlPf+HKP6fPA/P7eH0fMM8YMwn4JbDcDbmUUj7umbX7+Pu2I/xk/jhmj7F59b1vzE5l8awRPPWvUv5WdNir7+3L+i10Y8waoKaP19cbY2qdTzcC7j8iopRym+5uw8bSapraOs/6a2woqeZ/3t3FFROHsSRntBvTue6BqycwfWQ8P/pzEbsqGizJ4GvcPeB1B/Buby+KyBIRyRORvMpKPZ9UKSu8sukgC5dvZPovP+Cul/N5d9sRWju6XP77FfWt3PPqFtISI3n4hqzPzaDoTWEhQfzx5mlER4Tw7RfzqW/psCSHLxFj+r+kVkTSgL8ZYyb2sc7FwBPAXGNMv7chyc7ONnl5eWcQVSl1rlo7upj38CcMjYlg2oh4/lZ0hKqmNqLCgrl8wjC+kpXE3HT7yYObTW2d7KtsprSqiZLKZkorm9hyoJb64x28vXQO6UOiLf4/gvwDtSxcvoE56TaeuXUGwWd5daq/EJF8Y0z26V5zyz1FRWQy8DRwhStlrpSyxksbD3C0oY1lC6cya3QiP7vqPHL31fDO1sO8u72CtwrKiR0Uythh0RyobuZow//ddCJIICU+ksxh0fzb3NE+UeYA00fG84trJvDTt7bz6Ad7+OGXx1odyTLnXOgiMgL4K/ANY8yec4+klPKEprZOnvhnCRdm2Jg1OhGAkOAg5qTbmJNu48EFE1lbXMk7W49wsKaFuel2RtujGGOPYrR9MCMTIwkP+eKc5r5g0cwRbCur5w+fFDMxOZb5E4dZHckS/Ra6iLwKXATYRKQM+DkQCmCMeRJ4AEgEnnCOpXX29uuAUso6z63dR01zO/ddfvo92LCQIC4ZN5RLxg31crJzJyL854IJ7Kpo5L43Ckkf4hvDQd7m0hi6J+gYulLeU9/SwdyHPub8UYk8fWvg7m9V1Ldy9e/XEhMRwsqlc4iJOLcJwnxRX2PoeqWoUgPAU2tKaGrr5L7LM62O4lHDYiN44uZpHKxp4QevF9I9wOZR10JXKsBVNbXx3Lr9XD15OOclxVgdx+Nmjkrg/109ng8/O8ZjH++1Oo5XaaErFeCe+KSEts4uvn/Zmd89yF/dcsFIrpuWwv9+uJcPdx61Oo7XaKErFcCO1B/npdwDXDcthdH2wVbH8RoR4VdfncjE5Bi+/3ohpZVNVkfyCi10pQLYYx8VY4zhu5cOnL3zEyJCg3ly8XRCQ4JY8mL+OU114C+00JUKUAeqm/lz3iFumjmC1IRIq+NYIiU+kj8smsq+qmbueyPwD5JqoSsVoJZ9uJfgIGHpxelWR7HU7DE2/v2Kcby34yhPry21Oo5HaaErFYD2Hm3krcJybp2dxpCYCKvjWO6OuaOYk57ISxsPWh3Fo7TQlQpAj3ywh6iwEO6cN8bqKD5BRPjyhGEcrGlhf1Wz1XE8RgtdqQCzvbyed7dXcPvcUSREhVkdx2fkZNgBWLM3cKfu1kJXKsD87v3dxA4K5d8uHGV1FJ+SZotiREIka/ZooSul/ED+gRo+2V3Jt+eNDsh5TM7VhRk2NpRU094ZmDeX1kJXKkAYY3j4vd3YBodz2+w0q+P4pJxMO83tXeQfqO1/ZT+kha5UgFhXXM3G0hruvngMkWFuuXdNwJk9JpGQIAnYcXQtdKUCgDGG376/m+GxESw6f4TVcXxWdEQo00bEB+w4uha6UgHgo8+OUXiojnsuzfDZuwr5ipxMGzsON1DZ2Nb/yn5GC10pP9fd7dg7H5kYyfXTU6yO4/NyMh2nL64tDry9dC10pfzc37cdYVdFI9+/LJPQYP2R7s/E4bEkRIWxZk+V1VHcTr/7Svmxzq5uHv1gD5lDB/OVrOFWx/ELQUHC3HQbn+6tDLjJurTQlfJjbxWUU1rVzA++lElwkFgdx2/kZNqpampn55EGq6O4Vb+FLiLPisgxEdney+siIo+JSLGIFInINPfHVEqdqr2zm2Uf7WVScixfnjDM6jh+JSfDBgTeNACu7KE/D8zv4/UrgAznnyXAH889llKqPy/nHqCs9jj3XZ6JiO6dn4khMRGMGxYdcKcv9lvoxpg1QE0fqywAXjAOG4E4EUlyV0Cl1Bc1tnbw+4+LmT0mkXnOszbUmZmXaSf/QC3NAXQnI3eMoScDh3o8L3Mu+wIRWSIieSKSV1kZWP8yKuVNK9aUUtPczk/mj9O987OUk2mno8uwoaTa6ihu49WDosaY5caYbGNMtt2uexVKnY1jja2s+HQfV01OIis1zuo4fis7LZ5BocEBNY7ujkIvB1J7PE9xLlNKecCyD/fS0dXNjy4fa3UUvxYeEsys0QkBNY7ujkJfBdziPNtlFlBvjDnihq+rlDpFaWUTr20+xKLzR5Bmi7I6jt/LybSzv7qFg9UtVkdxC1dOW3wV2ACMFZEyEblDRO4UkTudq6wGSoFiYAVwl8fSKhVAGlo7MObMLmz57fu7CQ8J4p5LMjyUamA5MQ1AoAy79DvHpjHmpn5eN8Ddbkuk1ADQ2tHFnF9/zFWTkvifr01y6cBmwcFaVm+r4HuXZmCPDvdCysA32hZFctwg1uypZPGskVbHOWd6pahSFthxuJ7G1k5e23yIlzYe6Hd9Ywy/fncXtsFhfCtntBcSDgwiQk6mnfUl1XR0+f9djLTQlbLA1kP1AMxIi+c/39nJpn19XeoB/9xdSe6+Gr57aQaDw/XmFe40L9NGU1snBQfrrI5yzrTQlbJAUVkdQ2PCefrWGaQmRHLXy/kcrjt+2nW7ug2/+ccuRiZGsnCG3rzC3S4YYyM4SALibBctdKUssLWsnqyUOGIHhbLilum0dnRz50v5tHZ0fWHdlQXl7Kpo5EdfHktYiP7IulvsoFCmpMYFxIFR/XQo5WX1xzvYV9V88qKg9CHRPHJjFkVl9fz0re2fO/OltaOLRz7Yw+SUWK6cqDNqeEpOhp1t5fXUNLdbHeWcaKEr5WXbyhzj55NTYk8uu3zCML53aQZ/2VLGn9bvP7n8xQ0HKK87zv3zxxGk0+N6TE6mDWPgUz/fS9dCV8rLtpbVATA5Oe5zy793aQaXnTeUX/79MzaUVFN/vIM/fFLMvEw7s9Nt3g86gExOiSMuMtTv72Kkha6Ul209VMcoWxSxkaGfWx4UJDz69SzSEiO5+5UtPPjOThpaO/jJ/HEWJR04goOEOc67GJ3pxV6+RAtdKS8rKqv/3HBLT9ERoSy/JZuOzm7+sqWMa6ckM354jJcTDkzzMuwca2xjV0Wj1VHOmha6Ul50tKGVioZWJqfE9brOGPtgHls0layUWH7wpUzvhRvgLsx03sXIj09f1EJXyou2HqoDIKuXPfQTLh47hLeXziU1IdILqRRAUuwgMocO9uvTF7XQlfKiorJ6goOECcP7LnRljZwMO5v31dLS7p93MdJCV8qLtpbVkTk0mkFhwVZHUaeRk2mnvaub3NK+p2LwVVroSnmJMYaisvp+h1uUdWaOSiA8JIh/+ek4uha6Ul5yoLqF+uMdfR4QVdaKCA3m/NGJfjuOroWulJecuKAoK1X30H1ZToaN0spmymr97y5GWuhKeUlRWT3hIUFkDo22Oorqw7wTdzHyw6tGtdCV8pKth+qYMDyG0GD9sfNl6UMGkxQb4Zfno+snSykv6OzqZvvheh0/9wMiQk6GnXUlVXT62V2MtNCV8oK9x5po7ehminPKXOXbcjLtNLZ2njzu4S+00JXygqITMyzqKYt+YW66jSCBf/nZOLpLhS4i80Vkt4gUi8j9p3l9hIh8IiIFIlIkIle6P6pS/qvwUD3RESGkJUZZHUW5IDYylKzUOL8bR++30EUkGHgcuAIYD9wkIuNPWe1nwBvGmKnAQuAJdwdVyp8VldWRlRKnN6nwIzkZdorK6qhr8Z+7GLmyhz4TKDbGlBpj2oHXgAWnrGOAE3N8xgKH3RdRKf/W2tHF7opGHW7xMzmZNroNrC32n2EXVwo9GTjU43mZc1lPvwAWi0gZsBq453RfSESWiEieiORVVvrXrzJKna2dRxro7DZ6houfyUqJIzoixK+GXdx1UPQm4HljTApwJfCiiHzhaxtjlhtjso0x2Xa73U1vrZRvOzllrl4h6ldCgoOYm25jzZ4qv7mLkSuFXg6k9nie4lzW0x3AGwDGmA1ABKA3QVQKxxWiQ6LDGRYTYXUUdYZyMu1UNLSy91iT1VFc4kqhbwYyRGSUiIThOOi56pR1DgKXAojIeTgK3X9+T1HKg7aW1TE5JQ4RPSDqb3JOTgPgH3XWb6EbYzqBpcB7wGc4zmbZISIPisg1ztXuA74lIluBV4HbjL/8jqKUB9Uf76C0slmnzPVTyXGDGGOP8pvpdENcWckYsxrHwc6eyx7o8XgnMMe90ZTyf9vL6wGYrFeI+q2cTDuv5B6ktaOLiFDfvjGJXimqlAednDJX99D9Vk6mnbbObnL3+f5djLTQlfKgokP1jEyMJC4yzOoo6izNGpVIWEiQX4yja6Er5UEnDogq/zUoLJiZaQla6EoNZMcaWzlS36rDLQEgJ9PG3mNNHK47bnWUPmmhK+UhRYccB0Sz9ICo3ztx+uKnPn6vUS10pTykqKyOIIEJw2P6X1n5tLFDoxkaE+7zt6XTQlfKAw7XHecvW8o5LymGyDCXzg5WPkxEuDDDztriKrq6ffcSGy10pdysor6VRSs20nC8g//+6iSr4yg3ycm0U3+8w6fvYqSFrpQbHWtwlHllYxvP3z5Tx88DyIXpNkR8exoALXSl3KSysY1FT+dS0dDK87fPZPrIeKsjKTeKjwpjcnKsFrpSga6muZ3FT+dSVtvCs7fNYEZagtWRlAfkZNopPFRH/fEOq6Oclha6UueorqWdm5/OZX91M8/eOoNZoxOtjqQ8JCfTTreB9T56FyMtdKXOQX1LB4ufyaWksokVt2QzO11vAxDIpqTGER0ewhofPR9dC12ps9TY2sEtz+ayp6KJpxZPP3nxiQpcocFBzE5P9Nm7GGmhK3WW3sgrY2tZPX9YNJWLxw2xOo7ykgsz7JTXHaekstnqKF+gha7UWcotrWZkYiSXTxhmdRTlRfN8+C5GWuhKnQVjDJv31+jZLANQakIko2xRPjmOroWu1FkoPtZEbUsHM7XQB6ScDBsbS6tp7eiyOsrnaKErdRY27XfcvWbGKC30gSgn005rRzd5+2utjvI5WuhKnYXN+2qwR4eTlhhpdRRlgVmjEwkNFp8bdnGp0EVkvojsFpFiEbm/l3VuFJGdIrJDRF5xb0ylfMvm/bXMTEtARKyOoiwQFR5C9kjfu4tRv4UuIsHA48AVwHjgJhEZf8o6GcC/A3OMMROAe90fVSnfUFbbQnndcWak6VwtA1lOpp1dFY0cbWi1OspJruyhzwSKjTGlxph24DVgwSnrfAt43BhTC2CMOebemEr5js06fq5w3JYOfOv0RVcKPRk41ON5mXNZT5lApoisE5GNIjL/dF9IRJaISJ6I5FVW+s5GUOpMbNpXS3RECOOG6Z2IBrLzhsVgGxzOmr2+M6+Luw6KhgAZwEXATcAKEYk7dSVjzHJjTLYxJttu18uklX/atK+a7JHxBAfp+PlAFhQk5GTYWLu30mfuYuRKoZcDqT2epziX9VQGrDLGdBhj9gF7cBS8UgGluqmNkspmHW5RgGMcvbalg+3l9VZHAVwr9M1AhoiMEpEwYCGw6pR1VuLYO0dEbDiGYErdF1Mp37DZed7x+VroCpib4Vvj6P0WujGmE1gKvAd8BrxhjNkhIg+KyDXO1d4DqkVkJ/AJ8CNjTLWnQitllc37awgPCWJScpzVUZQPsA0OZ2JyjM+cj+7S7ciNMauB1acse6DHYwP8wPlHqYC1aV8NU1LjCAvRa/KUQ06GnafWlNLQ2kFMRKilWfRTqZSLmto62XG4npk63KJ6yMm009VtWF9s/aCEFrpSLtpyoJZugxa6+pxpI+KJCgvmH9uPWH7TCy10pVy0eX8NwUHCtBF6haj6P2EhQVw9eTgrCw9z7RPr2bSvxrIsWuhKuSh3Xw0ThscQFe7SoSc1gPz31ybx2xuyOFrfyo1PbWDJC3mUVjZ5PYcWulIuaOvsovBQnd7QQp1WcJBw/fQUPvnhRfzw8kzWFVdx+aNreODt7VQ3tXkthxa6Ui7YVlZPe2e3jp+rPg0KC2bpJRn880cXs3BmKi/nHiTnoU/43fu7qW/p8Pj7a6Er5YJc57io7qErV9ijw/mvayfx3r0XMm+snd9/XMzchz5m2Yd7aWz1XLFroSvlgs37a0gfMpiEqDCroyg/kj4kmiduns7q717IrNGJPPrhHi586BNe33zQI++nha5UP7q6Dfn7a3XvXJ218cNjWHFLNquWzmFqahxBHroxih6uV6ofuyoaaGzr1Plb1DmbnBLHc9+c6bHz1XUPXal+nDivWGdYVO7iqVsXaqEr1Y/N+2tIjhtEctwgq6Mo1SctdKX6YIxh075aPV1R+QUtdKX6sL+6haqmNj0gqvyCFrpSfdi0zzGD3sxROn+L8n1a6Er1YdO+WhKiwhhjH2x1FKX6pYWuVB82769hRlq8x85KUMqdtNCV6sWB6mYO1rQwc1Si1VGUcokWulK9eLvwMADzJw6zOIlSrtFCV+o0jDGsLCzn/FEJev658hta6Eqdxrbyekorm7l2arLVUZRymUuFLiLzRWS3iBSLyP19rHediBgRyXZfRKW8b2XBYcKCg7hyYpLVUZRyWb+FLiLBwOPAFcB44CYRGX+a9aKB7wG57g6plDd1dnWzauthLhk3hNjIUKvjKOUyV/bQZwLFxphSY0w78Bqw4DTr/RL4DdDqxnxKed36kmqqmtq4dupwq6ModUZcKfRk4FCP52XOZSeJyDQg1Rjz976+kIgsEZE8EcmrrKw847BKecPKgnJiIkK4aOwQq6ModUbO+aCoiAQBjwD39beuMWa5MSbbGJNtt9vP9a2VcruW9k7+saOCKyclEREabHUcpc6IK4VeDqT2eJ7iXHZCNDAR+KeI7AdmAav0wKjyRx/sPEpLe5ee3aL8kiuFvhnIEJFRIhIGLARWnXjRGFNvjLEZY9KMMWnARuAaY0yeRxIr5UErC8oZHhvBTJ1dUfmhfgvdGNMJLAXeAz4D3jDG7BCRB0XkGk8HVMpbqpvaWLO3imumJBMUpHO3KP/j0j1FjTGrgdWnLHugl3UvOvdYSnnf34qO0NVt+KoOtyg/pVeKKuW0srCcccOiGTss2uooSp0VLXSlgP1VzRQcrNO9c+XXtNCVwrF3LgLXTNGLiZT/0kJXA54xhrcLDzNrVCJJsTqzovJfWuhqwNtaVs++qmYdblF+TwtdDXgrC8oJCwli/iS9kYXyb1roakDr7Ormb0WHuey8IcRE6MyKyr9poasBbW1xFVVN7SyYosMtyv9poasBbWVBObGDQrlorE4Wp/yfFroasJrbOnlvx1GunJREeIjOrKj8nxa6GrA+2HmU4x1denaLChha6GrAequgnOS4QWSPjLc6ilJuoYWuBqTKxjbWFlexYMpwnVlRBQwtdDUg/a3osM6sqAKOFroakFYWHmZ8UgwZQ3VmRRU4tNDVgFNa2cTWQzqzogo8WuhqwFlZeFhnVlQBSQtdDSiOmRXLmT0mkaExEVbHUcqttNDVgFJwqI4D1S1cq5f6qwCkha4GlLcLygkPCWL+RJ1ZUQUelwpdROaLyG4RKRaR+0/z+g9EZKeIFInIRyIy0v1RlTo3HV3dvFN0hMvGDyVaZ1ZUAajfQheRYOBx4ApgPHCTiIw/ZbUCINsYMxl4E3jI3UGVOldr91ZR09yuwy0qYLmyhz4TKDbGlBpj2oHXgAU9VzDGfGKMaXE+3QikuDemUufurYJy4iJDmZepMyuqwORKoScDh3o8L3Mu680dwLune0FElohInojkVVZWup5SqXPU1NbJ+zsruHpyEmEheuhIBSa3frJFZDGQDTx8uteNMcuNMdnGmGy7XfeSlPe8v6OC1o5uHW5RAS3EhXXKgdQez1Ocyz5HRC4DfgrMM8a0uSeeUu7xVkE5KfGDmK4zK6oA5soe+mYgQ0RGiUgYsBBY1XMFEZkKPAVcY4w55v6YSp29Y42trCuu4topyYjozIoqcPVb6MaYTmAp8B7wGfCGMWaHiDwoItc4V3sYGAz8WUQKRWRVL19OKa97Z+sRug1cO1Uv9VeBzZUhF4wxq4HVpyx7oMfjy9ycSym3ebuwnInJMaQP0ZkVVWDTw/3qJGOM1RHcrqSyiaKyej0YqgYEl/bQVeAxxrCvqpn8A7Un/1Q0tPLrr03mqslJVsdzi7bOLn7+9g5CgoRrsnS4RQU+LfQBorWji23l9eQfqCVvfy1bDtZS09wOQExECNNGxhMeGsS9rxcQOyiUuRk2ixOfm65uw/dfL2RtcRW/uyGLITqzohoAtNADVGVjG/kHahwFfqCW7eX1dHQ5hlRG2aK4eOwQstPimT4ynnT7YIKChPqWDr6+fAPffjGPV5fMYnJKnLX/E2fJGMPPVm5j9bYKfnbVeVw3XS9cVgODWDVump2dbfLy8ix570DT1W3Ye6zRseftLPCDNY6ZGMKCg5icEsv0kY7ynjYyHtvg8F6/1tGGVq7743pa2rv4850XMMY+2Fv/G27z0D928cQ/S1h6cTo//PJYq+Mo5VYikm+MyT7ta1ro/qeprZOth+rI219L/sFaCg7U0tjWCYBtcNjJ8p4+MoGJyTGEhwSf0dffV9XM9X9cT0RoMH/5zmyGxfrPcMWKNaX8avVnLDp/BL+6dqKed64Cjha6HzPGUF53/HMHLz870kC3ARHIHBLN9LR4po+IJzstnhEJkW4pse3l9SxcvpHhcRG88e0LiIsMc8P/jWe9kXeIH79ZxFWTk3hs4VSCg7TMVeDRQvcjHV3d7Dzc8IWzTwAiw4KZOiKO6SPimZ6WwJTUOGIHeW5e7/UlVdz27GYmJsfw8r/NYlDYme3pe9N7Oyr4zkv5zEm38cytM3QCLhWw+ip0PShqsfbObgoP1bGuuIqNpdVsLaujtaMbgOS4QcwclXByCGXcsGhCgr1XVLPH2Hjspinc9fIWvvNyPituySbUi+/vqvUlVdzzagFZqXE8uXi6lrkasLTQvay727D7aCPriqtYW1zFpn01tLR3ESQwYXgsN80ccbLAk2IHWR2X+ROT+K9rJ/Efb23jx28W8bsbsgjyoaGMbWX1LHkhn7TESJ67bQZR4fqRVgOXfvq94FBNC+uKq1hXUs364iqqned/j7ZHcf30FGaPsXHB6ERiI33ztmiLzh9BTXMbv31/D/GRYfy/q8/ziYONJZVN3PrcJuIiQ3nh9vP9YpxfKU/SQveAmuZ2NpRUs7a4inXFVSdPIRwSHU5Opp056TbmpCf6xB64q+6+OJ2qpnaeXbcPW3QYd12Ubmmew3XH+cbTuQQJvHjH+X51Jo5SnqKF7gbH27vYtL/GsRdeXMWOww0ADA4PYdboRL45J4256TbShwz2iT3bsyEiPHD1eGpb2nnoH7tJiAxj4cwRlmSpaW7nG8/k0tjayatLZjHKFmVJDqV8jRb6Wejs6mZrWT3rnePgBQfraO/qJiw4iGkj47jvS5nMybAxOTnWqwcxPS0oSHj4+izqWjr4j7e2ERcZxvyJw7yaoamtk28+t4my2uO8cPtMJibHevX9lfJletqiC4wxFB9rOjmEkltaQ2NbJyIwPimGuek25qTbmJGW4NOn9rlLS3sni1bksvNIA3/65kwuGJPolfdt6+zi9uc3s7G0hqcWT+ey8UO98r5K+RI9bfEsHK47zrriKtaXVLOuuIpjjY676o1MjOQrU4YzZ4yNC8YkkhA18A7ERYaF8NxtM7jhqQ1864U8Xlsyy+N7yl3dhu+9Wsi64moeuTFLy1yp09BCd6pv6WBDafXJcfDSqmYAEqPCmJ1uY256IrPH2EhNiLQ4qW+Ijwrjhdtncv0f13Pbc5t4887ZpHloLNsYw3/8dRv/2FHBA1eP52vTdLItpU5nwA65tHZ0kX+glrXFVawvrmJbeT3dxnE15vmjEpxnotgYOzTap8679jXFx5q44cn1REeE8uadF7h9mtrmtk7+593PeGnjQe65JJ37LtfJttTAppf+4/iVfXt5PetKHHvgeftraevsJiRImDoijtljbMzNsJGVEqdXGp6hwkN1LFqxkZGJUby2ZJZbpiPo7ja8VVDOQ+/t4mhDG3fMHcXPrvKN89+VstKALPQTd+RxDKFUs76kioZWx4yE44ZFMyfdxtx0GzNGJTBYry48Z5/ureT25zczNTWeF+6YSUTo2R8czj9Qw4Pv7GRrWT1ZqXE8cPV4po+Md2NapfzXgDkoeqyh1bkH7hgLP1LvmNQqOW4QV0xMYrZzHNwe3ft84OrsXJhh55Ebp/Dd1wpY+koBTy6edsanbB6uO86v393Fqq2HGRoTziM3ZnHtlGQd8lLKRS4VuojMB5YBwcDTxphfn/J6OPACMB2oBr5ujNnv3qhf1NjaQW5pjWMcvKSKPUebAIiLDGX2mESWptuYM8bGyET3TCmr+vaVrOHUtrTzwNs7+Pe/buOh6ye7tN1b2jt58l+lLF9TgjHw3UvS+fa8MTovi1JnqN+fGBEJBh4HvgSUAZtFZJUxZmeP1e4Aao0x6SKyEPgN8HVPBC6tbGJlQTlri6vYWlZPV7chIjSIGWkJXDcthTnpNsYnxehenUVuuSCN6qZ2ln20l8TB4dx/xbhe1zXG8HbhYX797i4qGlq5enIS918xjpR4PZNIqbPhyi7QTKDYGFMKICKvAQuAnoW+APiF8/GbwB9ERIwHBuhLKpv5wyfFZKXG8Z15Y5iTbmPayLgzviuP8px7L8ugurmNJ/9VQmJUGN/KGf2FdQoO1vLg33ZScLCOScmx/GHRVLLTEixIq1TgcKXQk4FDPZ6XAef3to4xplNE6oFEoKrnSiKyBFgCMGLE2c0DcmGGjcKfX05MhG/OTKgc87785zUTqW3u4FerPyMhKuzkjZor6lv5zT928VZBOUOiw/ntDVl8baqOkyvlDl4dpDTGLAeWg+Msl7P5GhGhwed0BoXyjuAg4ZGvZ1F3vJ0f/6WIiNBgio818eS/SugyhrsvHsNdF6XrOLlSbuTKT1M5kNrjeYpz2enWKRORECAWx8FRNYCFhwTz1DeyWbRiI3e/sgWAqyY5xsn1ilul3M+VQt8MZIjIKBzFvRBYdMo6q4BbgQ3A9cDHnhg/V/5ncLhj3pdlH+3lqklJnD/aOxN5KTUQ9VvozjHxpcB7OE5bfNYYs0NEHgTyjDGrgGeAF0WkGKjBUfpKAZA4OJwHF0y0OoZSAc+lAUxjzGpg9SnLHujxuBW4wb3RlFJKnQmdtEQppQKEFrpSSgUILXSllAoQWuhKKRUgtNCVUipAaKErpVSA0EJXSqkAYdkdi0SkEjhwln/dxikTf/kQX83mq7nAd7P5ai7w3Wya68ydabaRxhj76V6wrNDPhYjk9XYLJqv5ajZfzQW+m81Xc4HvZtNcZ86d2XTIRSmlAoQWulJKBQh/LfTlVgfog69m89Vc4LvZfDUX+G42zXXm3JbNL8fQlVJKfZG/7qErpZQ6hRa6UkoFCL8rdBGZLyK7RaRYRO63MEeqiHwiIjtFZIeIfM+5/BciUi4ihc4/V1qUb7+IbHNmyHMuSxCRD0Rkr/O/8V7ONLbHdikUkQYRudeqbSYiz4rIMRHZ3mPZabeRODzm/NwVicg0L+d6WER2Od/7LRGJcy5PE5HjPbbdk57K1Ue2Xr9/IvLvzm22W0S+7OVcr/fItF9ECp3LvbbN+ugJz3zOjDF+8wfHHZNKgNFAGLAVGG9RliRgmvNxNLAHGA/8AvihD2yr/YDtlGUPAfc7H98P/Mbi72UFMNKqbQbkANOA7f1tI+BK4F1AgFlArpdzXQ6EOB//pkeutJ7rWbTNTvv9c/48bAXCgVHOn91gb+U65fXfAQ94e5v10RMe+Zz52x76TKDYGFNqjGkHXgMWWBHEGHPEGLPF+bgR+AxItiLLGVgA/Mn5+E/AtdZF4VKgxBhztlcLnzNjzBoct0zsqbdttAB4wThsBOJEJMlbuYwx7xtjOp1PN+K4WbvX9bLNerMAeM0Y02aM2QcU4/gZ9mouERHgRuBVT7x3X/roCY98zvyt0JOBQz2el+EDJSoiacBUINe5aKnz16VnvT2s0YMB3heRfBFZ4lw21BhzxPm4AhhqTTTAcd/Znj9gvrDNoPdt5Eufvdtx7MWdMEpECkTkXyJyoUWZTvf985VtdiFw1Bizt8cyr2+zU3rCI58zfyt0nyMig4G/APcaYxqAPwJjgCnAERy/6llhrjFmGnAFcLeI5PR80Th+v7PknFURCQOuAf7sXOQr2+xzrNxGvRGRnwKdwMvORUeAEcaYqcAPgFdEJMbLsXzy+9fDTXx+58Hr2+w0PXGSOz9n/lbo5UBqj+cpzmWWEJFQHN+kl40xfwUwxhw1xnQZY7qBFXjoV8z+GGPKnf89BrzlzHH0xK9vzv8esyIbjn9kthhjjjoz+sQ2c+ptG1n+2ROR24CrgZudJYBzOKPa+Tgfxzh1pjdz9fH984VtFgJ8DXj9xDJvb7PT9QQe+pz5W6FvBjJEZJRzL28hsMqKIM5xuWeAz4wxj/RY3nO866vA9lP/rheyRYlI9InHOA6obcexrW51rnYr8La3szl9bo/JF7ZZD71to1XALc6zEGYB9T1+ZfY4EZkP/Bi4xhjT0mO5XUSCnY9HAxlAqbdyOd+3t+/fKmChiISLyChntk3ezAZcBuwyxpSdWODNbdZbT+Cpz5k3jvS6+ajxlTiOFJcAP7Uwx1wcvyYVAYXOP1cCLwLbnMtXAUkWZBuN4+yCrcCOE9sJSAQ+AvYCHwIJFmSLAqqB2B7LLNlmOP5ROQJ04BirvKO3bYTjrIPHnZ+7bUC2l3MV4xhbPfFZe9K57nXO73EhsAX4igXbrNfvH/BT5zbbDVzhzVzO5c8Dd56yrte2WR894ZHPmV76r5RSAcLfhlyUUkr1QgtdKaUChBa6UkoFCC10pZQKEFroSikVILTQlVIqQGihK6VUgPj/u2FvFd+cPEsAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "x = [tr[9] for tr in transforms]\n",
     "plt.plot(x)"

--- a/src/mocoreg.py
+++ b/src/mocoreg.py
@@ -344,13 +344,13 @@ class mocoreg:
 
     def get_transforms(self):
         transform = itk.ComposeScaleSkewVersor3DTransform[itk.D].New()
-        transform_list = []
-        for trns in self.transforms:
+        transform_list = np.zeros([len(self.transforms), 12])
+        for i,trns in enumerate(self.transforms):
             m = trns.GetMatrix()
             o = trns.GetOffset()
             params = [m(x,y) for x in range(3) for y in range(3)]
             params.append(o[0])
             params.append(o[1])
             params.append(o[2])
-            transform_list.append(params)
+            transform_list[i] = params
         return transform_list


### PR DESCRIPTION
Hoping for matlab compatibility via nd.arrays.

This should work, per
https://www.mathworks.com/matlabcentral/answers/216498-passing-numpy-ndarray-from-python-to-matlab